### PR TITLE
Fix JNI reference leaks

### DIFF
--- a/native/CefClientHandler.cpp
+++ b/native/CefClientHandler.cpp
@@ -162,7 +162,7 @@ Java_org_cef_handler_CefClientHandler_N_1removeWindowHandler(
     jobject clientHandler,
     jobject windowHandler) {
   SetCefForJNIObject<WindowHandler>(env, windowHandler, nullptr,
-                                    "WindowHandler");
+                                    "CefWindowHandler");
 }
 
 JNIEXPORT void JNICALL

--- a/native/CefMessageRouter_N.cpp
+++ b/native/CefMessageRouter_N.cpp
@@ -109,6 +109,11 @@ Java_org_cef_browser_CefMessageRouter_1N_N_1RemoveHandler(
                             },
                             msgRouter, routerHandler));
   }
+  
+  // Remove JNI reference on jrouterhandler added by the ScopedJNIObject
+  SetCefForJNIObject<MessageRouterHandler>(env, jrouterHandler, nullptr,
+                                           "CefMessageRouterHandler");
+  
   return JNI_TRUE;
 }
 


### PR DESCRIPTION
I fixed 2 JNI object leaks.
The first in the CefClientHandler, one class name was not properly written, so the removeWindowHandler method didn"t work.
The second in CefMessageRouter_N, the handler was removed, but not its JNI reference.