### PR TITLE
Fix wrong bounds. An empty area at the top;

### DIFF
--- a/java/org/cef/browser/CefBrowserWr.java
+++ b/java/org/cef/browser/CefBrowserWr.java
@@ -378,7 +378,7 @@ class CefBrowserWr extends CefBrowser_N {
             }
         } else {
             synchronized (content_rect_) {
-                Rectangle bounds = component_.getBounds();
+                Rectangle bounds = null != canvas_ ? canvas_.getBounds() : component_.getBounds();
                 content_rect_ = new Rectangle((int) (bounds.getX() * scaleFactor_),
                         (int) (bounds.getY() * scaleFactor_),
                         (int) (bounds.getWidth() * scaleFactor_),


### PR DESCRIPTION
An empty area at the top; the scroll bar at the bottom is not fully displayed;

before:
![image](https://user-images.githubusercontent.com/10892032/174296237-7dd1853f-1fd0-427a-9fb8-e5bac2ead766.png)


after:
![image](https://user-images.githubusercontent.com/10892032/174296256-26fc5e0b-90c5-4ed4-9337-77e2793b28b1.png)
