### PR TITLE
Public Constructor for ColorType

### DIFF
--- a/java/org/cef/CefSettings.java
+++ b/java/org/cef/CefSettings.java
@@ -57,7 +57,7 @@ public class CefSettings {
     public class ColorType {
         private long color_value = 0;
 
-        private ColorType() {}
+        public ColorType() {}
 
         public ColorType(int alpha, int red, int green, int blue) {
             color_value = (alpha << 24) | (red << 16) | (green << 8) | (blue << 0);


### PR DESCRIPTION
Currently there will always be a white flash as that is the default background color that we cant change.
This change allows initialization of the ColorType class which is required to set `background_color` in `CefSettings.java` which will allow changing the background color to avoid the white flash.
