### PR TITLE
Update CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ set_property(GLOBAL PROPERTY OS_FOLDERS ON)
 
 # Specify the CEF distribution version.
 if(NOT DEFINED CEF_VERSION)
-  set(CEF_VERSION "119.4.3+gc76a3b9+chromium-119.0.6045.159")
+  set(CEF_VERSION "119.4.3+gc76a3b9+chromium-119.0.6045.199")
 endif()
 
 # Determine the platform.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ set_property(GLOBAL PROPERTY OS_FOLDERS ON)
 
 # Specify the CEF distribution version.
 if(NOT DEFINED CEF_VERSION)
-  set(CEF_VERSION "119.4.3+gc76a3b9+chromium-119.0.6045.199")
+  set(CEF_VERSION "119.4.7+g55e15c8+chromium-119.0.6045.199")
 endif()
 
 # Determine the platform.


### PR DESCRIPTION
There is currently no standard distribution available for build 159 on macos. Fixes the build on macos by updating to build 199.