### PR TITLE
Fix for persistent callbacks

### DIFF
--- a/java/org/cef/callback/CefQueryCallback_N.java
+++ b/java/org/cef/callback/CefQueryCallback_N.java
@@ -5,7 +5,10 @@
 package org.cef.callback;
 
 class CefQueryCallback_N extends CefNativeAdapter implements CefQueryCallback {
-    CefQueryCallback_N() {}
+    private boolean persistent_;
+
+    CefQueryCallback_N() {
+    }
 
     @Override
     protected void finalize() throws Throwable {
@@ -31,6 +34,15 @@ class CefQueryCallback_N extends CefNativeAdapter implements CefQueryCallback {
         }
     }
 
+    private void makePersistent() {
+        this.persistent_ = true;
+    }
+
+    private boolean getIsPersistent() {
+        return this.persistent_;
+    }
+
     private final native void N_Success(long self, String response);
+
     private final native void N_Failure(long self, int error_code, String error_message);
 }

--- a/native/CefQueryCallback_N.cpp
+++ b/native/CefQueryCallback_N.cpp
@@ -31,7 +31,12 @@ Java_org_cef_callback_CefQueryCallback_1N_N_1Success(JNIEnv* env,
   if (!callback)
     return;
   callback->Success(GetJNIString(env, response));
-  ClearSelf(env, obj);
+
+  bool persistent = false;
+  JNI_CALL_BOOLEAN_METHOD(persistent, env, obj, "getIsPersistent", "()Z");
+
+  if (!persistent)
+    ClearSelf(env, obj);
 }
 
 JNIEXPORT void JNICALL

--- a/native/message_router_handler.cpp
+++ b/native/message_router_handler.cpp
@@ -44,6 +44,9 @@ bool MessageRouterHandler::OnQuery(
 
   jboolean jresult = JNI_FALSE;
 
+  if (persistent)
+    JNI_CALL_VOID_METHOD(env, jcallback.get(), "makePersistent", "()V");
+
   JNI_CALL_METHOD(env, handle_, "onQuery",
                   "(Lorg/cef/browser/CefBrowser;Lorg/cef/browser/"
                   "CefFrame;JLjava/lang/String;ZLorg/cef/"


### PR DESCRIPTION
My fix for #398 

1. Add two private methods to CefQueryCallback_N.java, makePersistent and getIsPersistent, and a private boolean variable persistent_
2. In MessageRouterHandler::OnQuery (message_router_handler.cpp:28), check the value of persistent, if true use JNI_CALL_VOID_METHOD to call makePersistent. This will set a boolean value to true in CefQueryCallback_N
3. In CefQueryCallback_N.cpp::Success, use JNI_CALL_BOOLEAN_METHOD to call getIsPersistent, check the boolean value, and if its true then do not call ClearSelf

I am totally open to fixing anything here, this is my first attempt at open source contribution so please let me know if I'm forgetting something!