### PR TITLE
We had problems on windows 32bit systems using the reparenting feature.

### DIFF
--- a/native/CefBrowser_N.cpp
+++ b/native/CefBrowser_N.cpp
@@ -2122,8 +2122,10 @@ Java_org_cef_browser_CefBrowser_1N_N_1SetParent(JNIEnv* env,
                   std::move(callback));
 #else
   CefWindowHandle browserHandle = browser->GetHost()->GetWindowHandle();
-  CefWindowHandle parentHandle =
-      canvas ? util::GetWindowHandle(env, canvas) : kNullWindowHandle;
+  if (canvas != NULL)
+    parentHandle = util::GetWindowHandle(env, canvas);
+  else
+    parentHandle = TempWindow::GetWindowHandle();
   if (CefCurrentlyOn(TID_UI)) {
     util::SetParent(browserHandle, parentHandle, std::move(callback));
   } else {


### PR DESCRIPTION
Sometimes (timing issue) the JCEF native code in CefBrowser_N.cpp uses a wrong parent window handle. With this change the problem was gone, also see #321.

Reproduction:
The problem can happen on physical machines too but happen much more often when connected to remote machines (e.g. Citrix sessions, Remote Desktop, VMWares,...).
- Start detailed MainFrame
- Menu -> Tests -> Reparent
- Press the "Reparent </>" Button as fast as you can (Space bar helps) The bug then sometimes happens on the 5th try or you have to do this for a minute or so.