### PR TITLE
Workaround for CefBrowserWr.setBounds Incorrect Scaling Issue After M…

### DIFF
--- a/java/org/cef/browser/CefBrowserWr.java
+++ b/java/org/cef/browser/CefBrowserWr.java
@@ -190,8 +190,10 @@ class CefBrowserWr extends CefBrowser_N {
 
             @Override
             public void setBounds(int x, int y, int width, int height) {
-                super.setBounds(x, y, width, height);
-                wasResized((int) (width * scaleFactor_), (int) (height * scaleFactor_));
+                SwingUtilities.invokeLater(() -> {
+                    super.setBounds(x, y, width, height);
+                    wasResized((int) (width * scaleFactor_), (int) (height * scaleFactor_));
+                });
             }
 
             @Override


### PR DESCRIPTION
…onitor Change


Updated setBounds to use SwingUtilities.invokeLater to ensure that resizing is executed on the Swing Event Dispatch Thread (EDT)

This issue frequently occurs when moving a CefBrowser component between monitors with different DPI settings. Specifically, when setBounds is invoked, it continues to use the scale factor from the previous monitor, leading to incorrect scaling in Swing-based Java applications.

If you have suggestions for a better approach, I am open to updating this pull request accordingly.

[issue #438``](https://github.com/chromiumembedded/java-cef/issues/438)