### PR TITLE
Fix custom scheme registration on Linux

### DIFF
--- a/native/util_posix.cpp
+++ b/native/util_posix.cpp
@@ -25,12 +25,8 @@ std::string GetTempFileName(const std::string& identifer, bool useParentId) {
   if (!CefGetPath(PK_DIR_TEMP, tmpPath))
     tmpPath = "/tmp/";
 
-  // Ensure the path ends with a slash.
-  std::string pathStr = tmpPath.ToString();
-  if (!pathStr.empty() && pathStr.back() != '/')
-    pathStr += '/';
-
-  tmpName << tmpPath.ToString().c_str();
+  // ensure the temp path ends with a slash
+  tmpName << tmpPath.ToString() << (tmpPath.ToString().empty() || tmpPath.ToString().back() == '/' ? "" : "/");
   tmpName << "jcef-p" << (useParentId ? util::GetParentPid() : util::GetPid());
   tmpName << (identifer.empty() ? "" : "_") << identifer.c_str() << ".tmp";
   return tmpName.str();

--- a/native/util_posix.cpp
+++ b/native/util_posix.cpp
@@ -24,6 +24,12 @@ std::string GetTempFileName(const std::string& identifer, bool useParentId) {
   CefString tmpPath;
   if (!CefGetPath(PK_DIR_TEMP, tmpPath))
     tmpPath = "/tmp/";
+
+  // Ensure the path ends with a slash.
+  std::string pathStr = tmpPath.ToString();
+  if (!pathStr.empty() && pathStr.back() != '/')
+    pathStr += '/';
+
   tmpName << tmpPath.ToString().c_str();
   tmpName << "jcef-p" << (useParentId ? util::GetParentPid() : util::GetPid());
   tmpName << (identifer.empty() ? "" : "_") << identifer.c_str() << ".tmp";


### PR DESCRIPTION
The registration of custom schemes on Linux is currently broken because of a bug in the GetTempFileName() function in native/util_posix.cpp that causes java-cef to construct an invalid temp file path. It has already been discovered in issue #445.  
Currently java-cef incorrectly assumes that CefGetPath() will return a path with a trailing slash.

This PR adds a check that inserts a separator if necessary.