### PR TITLE
Fix jogl canvas error on MacOS & Update CEF to "142.0.17+g60aac24+chromium-142.0.7444.176"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ set_property(GLOBAL PROPERTY OS_FOLDERS ON)
 
 # Specify the CEF distribution version.
 if(NOT DEFINED CEF_VERSION)
-  set(CEF_VERSION "141.0.10+g1d65b0d+chromium-141.0.7390.123")
+  set(CEF_VERSION "142.0.17+g60aac24+chromium-142.0.7444.176")
 endif()
 
 # Determine the platform.

--- a/java/org/cef/browser/CefBrowserOsr.java
+++ b/java/org/cef/browser/CefBrowserOsr.java
@@ -199,11 +199,15 @@ class CefBrowserOsr extends CefBrowser_N implements CefRenderHandler {
 
             @Override
             public void addNotify() {
-                super.addNotify();
-                if (removed_) {
-                    notifyAfterParentChanged();
-                    removed_ = false;
+                if (!removed_) {
+                    // On MacOS it may happen that the platform has not correctly notified us of a previous removal.
+                    // In this case, the jogl canvas will throw an error because of a second add operation in a row.
+                    // We patch this by post-notifying the canvas of the removal first, before notifying the canvas as normal.
+                    super.removeNotify();
                 }
+                super.addNotify();
+                notifyAfterParentChanged();
+                removed_ = false;
             }
 
             @Override


### PR DESCRIPTION
Issue and fix:
A jogl canvas will throw an error if addNotify is called twice in a row without calling removeNotify in between. On MacOS the platform might sometimes not call removeNotify, so we post notify the canvas instead of its previous removal.

See https://github.com/jcefmaven/jcefmaven/issues/121#issuecomment-3591833759 for the conversation reporting and resolving this issue.

Linux AMD64 compilation run: https://github.com/jcefmaven/jcefbuild/actions/runs/19898860546

CEF version update:
Updated to v142.
Linux AMD64 compilation run: https://github.com/jcefmaven/jcefbuild/actions/runs/19898180014/job/57034163639

If this double-PR is not intended, you can also refer to the previous PR only updating the version: https://github.com/chromiumembedded/java-cef/pull/519