### PR TITLE
Support persistent & binary queries/callbacks

### DIFF
--- a/java/org/cef/callback/CefQueryCallback.java
+++ b/java/org/cef/callback/CefQueryCallback.java
@@ -20,7 +20,7 @@ public interface CefQueryCallback {
     /**
      * Notify the associated JavaScript onSuccess callback that the query has
      * completed successfully.
-     * @param response Response direct buffer passed to JavaScript. May be null.
+     * @param response Response buffer passed to JavaScript. May be null.
      */
     public void success(ByteBuffer response);
 

--- a/java/org/cef/callback/CefQueryCallback.java
+++ b/java/org/cef/callback/CefQueryCallback.java
@@ -22,4 +22,12 @@ public interface CefQueryCallback {
      * @param error_message Error message passed to JavaScript.
      */
     public void failure(int error_code, String error_message);
+
+    /**
+     * Returns whether this callback is persistent and therefore whether
+     * {@link CefQueryCallback#success(String)} may be called multiple times.
+     * Persistent queries must be explicitly canceled, either from the browser
+     * or via {@link CefQueryCallback#failure(int, String)}.
+     */
+    public boolean isPersistent();
 }

--- a/java/org/cef/callback/CefQueryCallback.java
+++ b/java/org/cef/callback/CefQueryCallback.java
@@ -4,6 +4,8 @@
 
 package org.cef.callback;
 
+import java.nio.ByteBuffer;
+
 /**
  * Interface representing a query callback.
  */
@@ -11,9 +13,16 @@ public interface CefQueryCallback {
     /**
      * Notify the associated JavaScript onSuccess callback that the query has
      * completed successfully.
-     * @param response Response passed to JavaScript.
+     * @param response Response text passed to JavaScript.
      */
     public void success(String response);
+
+    /**
+     * Notify the associated JavaScript onSuccess callback that the query has
+     * completed successfully.
+     * @param response Response direct buffer passed to JavaScript. May be null.
+     */
+    public void success(ByteBuffer response);
 
     /**
      * Notify the associated JavaScript onFailure callback that the query has

--- a/java/org/cef/callback/CefQueryCallback_N.java
+++ b/java/org/cef/callback/CefQueryCallback_N.java
@@ -4,6 +4,8 @@
 
 package org.cef.callback;
 
+import java.nio.ByteBuffer;
+
 class CefQueryCallback_N extends CefNativeAdapter implements CefQueryCallback {
     CefQueryCallback_N() {}
 
@@ -17,6 +19,15 @@ class CefQueryCallback_N extends CefNativeAdapter implements CefQueryCallback {
     public void success(String response) {
         try {
             N_Success(getNativeRef(null), response, isPersistent());
+        } catch (UnsatisfiedLinkError ule) {
+            ule.printStackTrace();
+        }
+    }
+
+    @Override
+    public void success(ByteBuffer response) {
+        try {
+            N_SuccessBinary(getNativeRef(null), response, isPersistent());
         } catch (UnsatisfiedLinkError ule) {
             ule.printStackTrace();
         }
@@ -37,6 +48,7 @@ class CefQueryCallback_N extends CefNativeAdapter implements CefQueryCallback {
     }
 
     private final native void N_Success(long self, String response, boolean persistent);
+    private final native void N_SuccessBinary(long self, ByteBuffer response, boolean persistent);
     private final native void N_Failure(long self, int error_code, String error_message);
 }
 

--- a/java/org/cef/callback/CefQueryCallback_N.java
+++ b/java/org/cef/callback/CefQueryCallback_N.java
@@ -16,7 +16,7 @@ class CefQueryCallback_N extends CefNativeAdapter implements CefQueryCallback {
     @Override
     public void success(String response) {
         try {
-            N_Success(getNativeRef(null), response);
+            N_Success(getNativeRef(null), response, isPersistent());
         } catch (UnsatisfiedLinkError ule) {
             ule.printStackTrace();
         }
@@ -31,6 +31,20 @@ class CefQueryCallback_N extends CefNativeAdapter implements CefQueryCallback {
         }
     }
 
-    private final native void N_Success(long self, String response);
+    @Override
+    public boolean isPersistent() {
+        return false;
+    }
+
+    private final native void N_Success(long self, String response, boolean persistent);
     private final native void N_Failure(long self, int error_code, String error_message);
+}
+
+class CefQueryCallback_N_Persistent extends CefQueryCallback_N {
+    CefQueryCallback_N_Persistent() {}
+
+    @Override
+    public boolean isPersistent() {
+        return true;
+    }
 }

--- a/java/org/cef/handler/CefMessageRouterHandler.java
+++ b/java/org/cef/handler/CefMessageRouterHandler.java
@@ -9,18 +9,21 @@ import org.cef.browser.CefFrame;
 import org.cef.callback.CefNative;
 import org.cef.callback.CefQueryCallback;
 
+import java.nio.ByteBuffer;
+
 /**
  * Implement this interface to handle queries. All methods will be executed on the browser process
  * UI thread.
  */
 public interface CefMessageRouterHandler extends CefNative {
     /**
-     * Called when the browser receives a JavaScript query.
+     * Called when the browser receives a JavaScript text query.
      *
      * @param browser The corresponding browser.
      * @param frame The frame generating the event. Instance only valid within the scope of this
      *         method.
      * @param queryId The unique ID for the query.
+     * @param request The query text.
      * @param persistent True if the query is persistent.
      * @param callback Object used to continue or cancel the query asynchronously.
      * @return True to handle the query or false to propagate the query to other registered
@@ -29,6 +32,24 @@ public interface CefMessageRouterHandler extends CefNative {
      *         callback.
      */
     public boolean onQuery(CefBrowser browser, CefFrame frame, long queryId, String request,
+            boolean persistent, CefQueryCallback callback);
+
+    /**
+     * Called when the browser receives a JavaScript binary query.
+     *
+     * @param browser The corresponding browser.
+     * @param frame The frame generating the event. Instance only valid within the scope of this
+     *         method.
+     * @param queryId The unique ID for the query.
+     * @param request The query direct buffer. Valid only for the scope of this method.
+     * @param persistent True if the query is persistent.
+     * @param callback Object used to continue or cancel the query asynchronously.
+     * @return True to handle the query or false to propagate the query to other registered
+     *         handlers, if any. If no handlers return true from this method then the query will be
+     *         automatically canceled with an error code of -1 delivered to the JavaScript onFailure
+     *         callback.
+     */
+    public boolean onQuery(CefBrowser browser, CefFrame frame, long queryId, ByteBuffer request,
             boolean persistent, CefQueryCallback callback);
 
     /**

--- a/java/org/cef/handler/CefMessageRouterHandlerAdapter.java
+++ b/java/org/cef/handler/CefMessageRouterHandlerAdapter.java
@@ -9,6 +9,8 @@ import org.cef.browser.CefFrame;
 import org.cef.callback.CefNativeAdapter;
 import org.cef.callback.CefQueryCallback;
 
+import java.nio.ByteBuffer;
+
 /**
  * An abstract adapter class for receiving message router events.
  * The methods in this class are empty.
@@ -18,6 +20,12 @@ public abstract class CefMessageRouterHandlerAdapter
         extends CefNativeAdapter implements CefMessageRouterHandler {
     @Override
     public boolean onQuery(CefBrowser browser, CefFrame frame, long queryId, String request,
+            boolean persistent, CefQueryCallback callback) {
+        return false;
+    }
+
+    @Override
+    public boolean onQuery(CefBrowser browser, CefFrame frame, long queryId, ByteBuffer request,
             boolean persistent, CefQueryCallback callback) {
         return false;
     }

--- a/java/tests/detailed/handler/MessageRouterHandlerEx.java
+++ b/java/tests/detailed/handler/MessageRouterHandlerEx.java
@@ -47,6 +47,14 @@ public class MessageRouterHandlerEx extends CefMessageRouterHandlerAdapter {
                 router_ = null;
                 callback.success("");
             }
+        } else if (request.startsWith("doPersistent")) {
+            if (persistent) {
+                callback.success("Hello,");
+                callback.success("World!");
+                callback.failure(0, "Finished");
+            } else {
+                callback.failure(-1, "Request not marked as persistent");
+            }
         } else {
             // not handled
             return false;

--- a/java/tests/detailed/handler/MessageRouterHandlerEx.java
+++ b/java/tests/detailed/handler/MessageRouterHandlerEx.java
@@ -12,6 +12,8 @@ import org.cef.browser.CefMessageRouter.CefMessageRouterConfig;
 import org.cef.callback.CefQueryCallback;
 import org.cef.handler.CefMessageRouterHandlerAdapter;
 
+import java.nio.ByteBuffer;
+
 public class MessageRouterHandlerEx extends CefMessageRouterHandlerAdapter {
     private final CefClient client_;
     private final CefMessageRouterConfig config_ =
@@ -54,6 +56,28 @@ public class MessageRouterHandlerEx extends CefMessageRouterHandlerAdapter {
                 callback.failure(0, "Finished");
             } else {
                 callback.failure(-1, "Request not marked as persistent");
+            }
+        } else {
+            // not handled
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean onQuery(CefBrowser browser, CefFrame frame, long query_id, ByteBuffer request,
+            boolean persistent, CefQueryCallback callback) {
+        if (request != null) {
+            int size = request.remaining();
+            ByteBuffer response = ByteBuffer.allocateDirect(size);
+            // reverse bytes
+            for (int i = 0; i < size; i++) {
+                byte b = request.get(i);
+                response.put(size - i - 1, b);
+            }
+            callback.success(response);
+            if (persistent) {
+                callback.failure(0, "Finished");
             }
         } else {
             // not handled

--- a/java/tests/detailed/handler/MessageRouterHandlerEx.java
+++ b/java/tests/detailed/handler/MessageRouterHandlerEx.java
@@ -19,6 +19,7 @@ public class MessageRouterHandlerEx extends CefMessageRouterHandlerAdapter {
     private final CefMessageRouterConfig config_ =
             new CefMessageRouterConfig("myQuery", "myQueryAbort");
     private CefMessageRouter router_ = null;
+    private boolean binary_direct_ = false;
 
     public MessageRouterHandlerEx(final CefClient client) {
         client_ = client;
@@ -68,8 +69,10 @@ public class MessageRouterHandlerEx extends CefMessageRouterHandlerAdapter {
     public boolean onQuery(CefBrowser browser, CefFrame frame, long query_id, ByteBuffer request,
             boolean persistent, CefQueryCallback callback) {
         if (request != null) {
-            int size = request.remaining();
-            ByteBuffer response = ByteBuffer.allocateDirect(size);
+            int size = request.capacity();
+            boolean direct = (binary_direct_ = !binary_direct_);
+            ByteBuffer response = direct ? ByteBuffer.allocateDirect(size)
+                                         : ByteBuffer.allocate(size);
             // reverse bytes
             for (int i = 0; i < size; i++) {
                 byte b = request.get(i);
@@ -77,7 +80,8 @@ public class MessageRouterHandlerEx extends CefMessageRouterHandlerAdapter {
             }
             callback.success(response);
             if (persistent) {
-                callback.failure(0, "Finished");
+                callback.failure(0, direct ? "Finished (direct)"
+                                           : "Finished (array)");
             }
         } else {
             // not handled

--- a/java/tests/detailed/handler/binding_test2.html
+++ b/java/tests/detailed/handler/binding_test2.html
@@ -17,6 +17,20 @@ function toggleButton() {
   });
 }
 
+function doPersistent() {
+  document.getElementById('persist').value = '';
+  window.cefQuery({
+    request: 'doPersistent',
+    persistent: true,
+    onSuccess: function(response) {
+      document.getElementById('persist').value += ' ' + response;
+    },
+    onFailure: function(error_code, error_message) {
+      document.getElementById('persist').value += ' ' + error_code + ' ' + error_message;
+    }
+  });
+}
+
 function execute(cmd) {
   window.cefQuery({
     request: cmd,
@@ -75,6 +89,11 @@ Second message router:
 <input type="button" id="jcefOff" value="Disable myQuery" onclick="execute('disableExt');" />
 <br/><input type="button" onclick="getJavaVersion();" value="Test"/>
 <input type="text" id="result" size="80" readonly />
+<br/><p>This button tests persistent queries. When the button is pressed, it clears the output,
+and when it receives a success message, it appends it to the output. When it finally receives
+a failure message, it appends the error_code followed by the error_message.</p>
+<input type="button" onclick="doPersistent();" value="Persist"/>
+<input type="text" id="persist" size="80" readonly />
 </form>
 </body>
 </html>

--- a/java/tests/detailed/handler/binding_test2.html
+++ b/java/tests/detailed/handler/binding_test2.html
@@ -23,10 +23,34 @@ function doPersistent() {
     request: 'doPersistent',
     persistent: true,
     onSuccess: function(response) {
-      document.getElementById('persist').value += ' ' + response;
+      document.getElementById('persist').value += ' MESSAGE: [ ' + response + '];';
     },
     onFailure: function(error_code, error_message) {
-      document.getElementById('persist').value += ' ' + error_code + ' ' + error_message;
+      document.getElementById('persist').value += ' FINISHED: ' + error_code + ' ' + error_message;
+    }
+  });
+}
+
+function doBinary() {
+  document.getElementById('binary').value = 'ORIGINAL: [';
+  const binaryData = new Uint8Array([10, 20, 30, 40, 50]);
+  for (let i = 0; i < binaryData.length; i++) {
+    document.getElementById('binary').value += ' ' + binaryData.at(i);
+  }
+  document.getElementById('binary').value += ' ];';
+  window.cefQuery({
+    request: binaryData.buffer,
+    persistent: true,
+    onSuccess: function(response) {
+      document.getElementById('binary').value += ' RESPONSE: [';
+      const echoedBinaryData = new Uint8Array(response);
+      for (let i = 0; i < echoedBinaryData.length; i++) {
+        document.getElementById('binary').value += ' ' + echoedBinaryData.at(i);
+      }
+      document.getElementById('binary').value += ' ];';
+    },
+    onFailure: function(error_code, error_message) {
+      document.getElementById('binary').value += ' FINISHED: ' + error_code + ' ' + error_message;
     }
   });
 }
@@ -94,6 +118,13 @@ and when it receives a success message, it appends it to the output. When it fin
 a failure message, it appends the error_code followed by the error_message.</p>
 <input type="button" onclick="doPersistent();" value="Persist"/>
 <input type="text" id="persist" size="80" readonly />
+<br/><p>This button tests binary queries. When the button is pressed, it clears the output and
+replaces it with a representation of the binary data sent in the query. When it receives a
+success message, it appends a similar representation of the binary data received (which has
+been reversed by Java). When it finally receives a failure message, it appends the error_code
+followed by the error_message.</p>
+<input type="button" onclick="doBinary();" value="Binary"/>
+<input type="text" id="binary" size="80" readonly />
 </form>
 </body>
 </html>

--- a/native/CefQueryCallback_N.cpp
+++ b/native/CefQueryCallback_N.cpp
@@ -26,11 +26,14 @@ JNIEXPORT void JNICALL
 Java_org_cef_callback_CefQueryCallback_1N_N_1Success(JNIEnv* env,
                                                      jobject obj,
                                                      jlong self,
-                                                     jstring response) {
+                                                     jstring response,
+                                                     jboolean persistent) {
   CefRefPtr<CefQueryCallback> callback = GetSelf(self);
   if (!callback)
     return;
   callback->Success(GetJNIString(env, response));
+  if (persistent)
+      return;
   ClearSelf(env, obj);
 }
 

--- a/native/CefQueryCallback_N.cpp
+++ b/native/CefQueryCallback_N.cpp
@@ -33,7 +33,7 @@ Java_org_cef_callback_CefQueryCallback_1N_N_1Success(JNIEnv* env,
     return;
   callback->Success(GetJNIString(env, response));
   if (persistent)
-      return;
+    return;
   ClearSelf(env, obj);
 }
 
@@ -47,10 +47,34 @@ Java_org_cef_callback_CefQueryCallback_1N_N_1SuccessBinary(
   CefRefPtr<CefQueryCallback> callback = GetSelf(self);
   if (!callback)
     return;
-  callback->Success(GetJNIByteBufferData(env, response),
-                    GetJNIByteBufferLength(env, response));
+  jboolean isDirect = JNI_TRUE;
+  if (response)
+    JNI_CALL_BOOLEAN_METHOD(isDirect, env, response, "isDirect", "()Z");
+  if (isDirect != JNI_FALSE) {
+    callback->Success(GetJNIByteBufferData(env, response),
+                      GetJNIByteBufferLength(env, response));
+  } else {
+    jobject responseArrayObj = nullptr;
+    jint responseOffset = 0;
+    jint responseLength = 0;
+    JNI_CALL_METHOD(env, response, "array", "()[B", Object, responseArrayObj);
+    JNI_CALL_METHOD(env, response, "arrayOffset", "()I", Int, responseOffset);
+    JNI_CALL_METHOD(env, response, "capacity", "()I", Int, responseLength);
+    jbyteArray responseArray = static_cast<jbyteArray>(responseArrayObj);
+    jsize responseArrayLength = env->GetArrayLength(responseArray);
+    if (responseLength >= 0 && responseLength <= responseArrayLength &&
+        responseOffset >= 0 && responseOffset < responseLength) {
+      // isCopy is ignored
+      jboolean isCopy = JNI_FALSE;
+      jbyte *responseBytes = env->GetByteArrayElements(responseArray, &isCopy);
+      callback->Success(static_cast<void*>(responseBytes + responseOffset),
+                        static_cast<size_t>(responseLength));
+      // JNI_ABORT: no need to copy back the data
+      env->ReleaseByteArrayElements(responseArray, responseBytes, JNI_ABORT);
+    }
+  }
   if (persistent)
-      return;
+    return;
   ClearSelf(env, obj);
 }
 

--- a/native/CefQueryCallback_N.cpp
+++ b/native/CefQueryCallback_N.cpp
@@ -38,6 +38,23 @@ Java_org_cef_callback_CefQueryCallback_1N_N_1Success(JNIEnv* env,
 }
 
 JNIEXPORT void JNICALL
+Java_org_cef_callback_CefQueryCallback_1N_N_1SuccessBinary(
+    JNIEnv* env,
+    jobject obj,
+    jlong self,
+    jobject response,
+    jboolean persistent) {
+  CefRefPtr<CefQueryCallback> callback = GetSelf(self);
+  if (!callback)
+    return;
+  callback->Success(GetJNIByteBufferData(env, response),
+                    GetJNIByteBufferLength(env, response));
+  if (persistent)
+      return;
+  ClearSelf(env, obj);
+}
+
+JNIEXPORT void JNICALL
 Java_org_cef_callback_CefQueryCallback_1N_N_1Failure(JNIEnv* env,
                                                      jobject obj,
                                                      jlong self,

--- a/native/CefQueryCallback_N.h
+++ b/native/CefQueryCallback_N.h
@@ -21,6 +21,18 @@ Java_org_cef_callback_CefQueryCallback_1N_N_1Success(JNIEnv*,
 
 /*
  * Class:     org_cef_callback_CefQueryCallback_N
+ * Method:    N_Success
+ * Signature: (JLjava/nio/ByteBuffer;Z)V
+ */
+JNIEXPORT void JNICALL
+Java_org_cef_callback_CefQueryCallback_1N_N_1SuccessBinary(JNIEnv*,
+                                                           jobject,
+                                                           jlong,
+                                                           jobject,
+                                                           jboolean);
+
+/*
+ * Class:     org_cef_callback_CefQueryCallback_N
  * Method:    N_Failure
  * Signature: (JILjava/lang/String;)V
  */

--- a/native/CefQueryCallback_N.h
+++ b/native/CefQueryCallback_N.h
@@ -10,13 +10,14 @@ extern "C" {
 /*
  * Class:     org_cef_callback_CefQueryCallback_N
  * Method:    N_Success
- * Signature: (JLjava/lang/String;)V
+ * Signature: (JLjava/lang/String;Z)V
  */
 JNIEXPORT void JNICALL
 Java_org_cef_callback_CefQueryCallback_1N_N_1Success(JNIEnv*,
                                                      jobject,
                                                      jlong,
-                                                     jstring);
+                                                     jstring,
+                                                     jboolean);
 
 /*
  * Class:     org_cef_callback_CefQueryCallback_N

--- a/native/message_router_handler.cpp
+++ b/native/message_router_handler.cpp
@@ -70,6 +70,49 @@ bool MessageRouterHandler::OnQuery(
   return jresult != JNI_FALSE;
 }
 
+bool MessageRouterHandler::OnQuery(
+    CefRefPtr<CefBrowser> browser,
+    CefRefPtr<CefFrame> frame,
+    int64_t query_id,
+    CefRefPtr<const CefBinaryBuffer> request,
+    bool persistent,
+    CefRefPtr<CefMessageRouterBrowserSide::Callback> callback) {
+  ScopedJNIEnv env;
+  if (!env)
+    return false;
+
+  ScopedJNIBrowser jbrowser(env, browser);
+  ScopedJNIFrame jframe(env, frame);
+  jframe.SetTemporary();
+  ScopedJNIObjectLocal jrequest(
+      env,
+      env->NewDirectByteBuffer(const_cast<void*>(request->GetData()),
+                               (jlong)request->GetSize()));
+
+  // Uses a subclass of CefQueryCallback_N for persistent queries, as otherwise
+  // the reference to the CefMessageRouterBrowserSide::Callback gets cleared
+  // immediately when N_Success is called
+  ScopedJNIQueryCallback jcallback(env, callback, persistent);
+
+  jboolean jresult = JNI_FALSE;
+
+  JNI_CALL_METHOD(env, handle_, "onQuery",
+                  "(Lorg/cef/browser/CefBrowser;Lorg/cef/browser/"
+                  "CefFrame;JLjava/nio/ByteBuffer;ZLorg/cef/"
+                  "callback/CefQueryCallback;)Z",
+                  Boolean, jresult, jbrowser.get(), jframe.get(),
+                  (jlong)query_id, jrequest.get(),
+                  persistent ? JNI_TRUE : JNI_FALSE, jcallback.get());
+
+  if (jresult == JNI_FALSE) {
+    // If the Java method returns "false" the callback won't be used and
+    // the reference can therefore be removed.
+    jcallback.SetTemporary();
+  }
+
+  return jresult != JNI_FALSE;
+}
+
 void MessageRouterHandler::OnQueryCanceled(CefRefPtr<CefBrowser> browser,
                                            CefRefPtr<CefFrame> frame,
                                            int64_t query_id) {

--- a/native/message_router_handler.cpp
+++ b/native/message_router_handler.cpp
@@ -13,11 +13,16 @@ using CefQueryCallback = CefMessageRouterBrowserSide::Callback;
 // JNI CefQueryCallback object.
 class ScopedJNIQueryCallback : public ScopedJNIObject<CefQueryCallback> {
  public:
-  ScopedJNIQueryCallback(JNIEnv* env, CefRefPtr<CefQueryCallback> obj)
-      : ScopedJNIObject<CefQueryCallback>(env,
-                                          obj,
-                                          "org/cef/callback/CefQueryCallback_N",
-                                          "CefQueryCallback") {}
+  ScopedJNIQueryCallback(JNIEnv* env,
+                         CefRefPtr<CefQueryCallback> obj,
+                         bool persistent)
+      : ScopedJNIObject<CefQueryCallback>(
+            env,
+            obj,
+            persistent ?
+              "org/cef/callback/CefQueryCallback_N_Persistent" :
+              "org/cef/callback/CefQueryCallback_N",
+            "CefQueryCallback") {}
 };
 
 }  // namespace
@@ -40,7 +45,11 @@ bool MessageRouterHandler::OnQuery(
   ScopedJNIFrame jframe(env, frame);
   jframe.SetTemporary();
   ScopedJNIString jrequest(env, request);
-  ScopedJNIQueryCallback jcallback(env, callback);
+
+  // Uses a subclass of CefQueryCallback_N for persistent queries, as otherwise
+  // the reference to the CefMessageRouterBrowserSide::Callback gets cleared
+  // immediately when N_Success is called
+  ScopedJNIQueryCallback jcallback(env, callback, persistent);
 
   jboolean jresult = JNI_FALSE;
 

--- a/native/message_router_handler.h
+++ b/native/message_router_handler.h
@@ -25,6 +25,12 @@ class MessageRouterHandler : public CefMessageRouterBrowserSide::Handler,
                        const CefString& request,
                        bool persistent,
                        CefRefPtr<Callback> callback) override;
+  virtual bool OnQuery(CefRefPtr<CefBrowser> browser,
+                       CefRefPtr<CefFrame> frame,
+                       int64_t query_id,
+                       CefRefPtr<const CefBinaryBuffer> request,
+                       bool persistent,
+                       CefRefPtr<Callback> callback) override;
   virtual void OnQueryCanceled(CefRefPtr<CefBrowser> browser,
                                CefRefPtr<CefFrame> frame,
                                int64_t query_id) override;


### PR DESCRIPTION
Fixes #398
After trying to (ab)use JNA to manually pre-increment the CefQueryCallback native reference count, I found my way here and discovered that #476 existed, but was made to the wrong repo. This is my approach to solving the problem:
- Add a (j)boolean parameter at the end of CefQueryCallback_N.N_Success to indicate whether the query is persistent
  - Decrement the reference count if and only if this parameter is false
  - CefQueryCallback_N.N_Failure should **not** have this, as the documentation in [cef_message_router.h](https://github.com/chromiumembedded/cef/blob/d29a3ecf286ecb51b04c42445e801b949b1a7db1/include/wrapper/cef_message_router.h#L86) specifies that the query is canceled (and therefore the callback becomes invalid) when the Callback::Failure function is called
- Add a new method to CefQueryCallback: boolean isPersistent(), which can be used on the Java side to check if the query is persistent (instead of lugging around a callback + boolean pair)
- Store whether the query is persistent in the Java runtime type of the callback wrapper instead of a field
  - This subclasses CefQueryCallback_N with CefQueryCallback_N_Persistent which overrides the isPersistent method to return true

Regarding binary queries/successes:
- Queries:
  - Override MessageRouterHandler::OnQuery(..., CefRefPtr<const CefBinaryBuffer> request, ...)
  - Wrap the CefBinaryBuffer in a direct byte buffer _(javadocs note that the buffer is only valid in certain scope)_
  - Forward to new method CefMessageRouterHandler.onQuery(..., ByteBuffer request, ...)
- Successes:
  - Add new method CefQueryCallback(_N).success(ByteBuffer response) ~~_(javadocs note that the buffer must be direct)_~~
  - Forward this to new native method CefQueryCallback_N.N_SuccessBinary(..., ByteBuffer response, ...)
    - Supports both direct and array-backed buffers
  - Call the native callback binary Success variant

Test cases have been added to the "detailed handler test" in MessageRouterHandlerEx and binding_test2.html