### PR TITLE
Fix DevTools command completion race

### DIFF
--- a/java/org/cef/browser/CefDevToolsClient.java
+++ b/java/org/cef/browser/CefDevToolsClient.java
@@ -36,7 +36,6 @@ public class CefDevToolsClient implements AutoCloseable {
                     future.completeExceptionally(
                             new DevToolsException("DevTools method failed", result));
                 }
-                removeQueuedCommand(messageId);
             }
 
             @Override
@@ -61,10 +60,6 @@ public class CefDevToolsClient implements AutoCloseable {
 
     private CompletableFuture<String> getQueuedCommand(Integer messageId) {
         return queuedCommands_.computeIfAbsent(messageId, key -> new CompletableFuture<>());
-    }
-
-    private void removeQueuedCommand(Integer messageId) {
-        queuedCommands_.remove(messageId);
     }
 
     /**
@@ -105,8 +100,11 @@ public class CefDevToolsClient implements AutoCloseable {
             return future;
         }
 
-        return browser_.executeDevToolsMethod(method, parametersAsJson)
-                .thenCompose(this::getQueuedCommand);
+        return browser_.executeDevToolsMethod(method, parametersAsJson).thenCompose(messageId -> {
+            CompletableFuture<String> queuedCommand = getQueuedCommand(messageId);
+            return queuedCommand.whenComplete(
+                    (result, throwable) -> queuedCommands_.remove(messageId, queuedCommand));
+        });
     }
 
     /**


### PR DESCRIPTION
Commit 7ac5c1f fixed a `queuedCommands_` memory leak by adding `removeQueuedCommand(messageId)` at the end of `onDevToolsMethodResult`. Unfortunately this introduced a race condition that causes DevTools calls to hang indefinitely (or, if the caller adds `orTimeout`, to throw a `TimeoutException`).

## The race

`executeDevToolsMethod` chains two async steps:

1. Submit the DevTools command to CEF → receive the assigned `messageId` back via a callback
2. Look up or create a `CompletableFuture<String>` in `queuedCommands_` for that `messageId` (via `thenCompose`)

The leak fix assumed that by the time the observer's `onDevToolsMethodResult` fires, step 2 has already completed and the queued future is bound to the caller. That assumption holds in the common case, but it is not guaranteed. The two callbacks — the message-id callback and the observer result callback — cross the JNI boundary independently and can be scheduled in either order.

When the result arrives before step 2 runs:

- Observer fires, calls `getQueuedCommand(messageId)` → creates a new `CompletableFuture` F1, completes it, removes it from the map
- Step 2 runs, calls `getQueuedCommand(messageId)` → map entry is gone, creates a new `CompletableFuture` F2
- F2 is what the caller holds; it is never completed → indefinite hang

This was confirmed with an instrumentation build that added lifecycle logging across the Java/native boundary. The observed log sequence for a reproducing `Network.setCacheDisabled` call matched the scenario above exactly, including a warning "DevTools result arrived before consumer bound queued future."

## Fix

Remove the observer-side cleanup. Instead, clean up from the consumer side — specifically from the `whenComplete` attached in `executeDevToolsMethod`, using the two-argument `Map.remove(key, value)` overload to avoid accidentally deleting a newer mapping for a reused message id:

```java
return browser_.executeDevToolsMethod(method, parametersAsJson).thenCompose(messageId -> {
    CompletableFuture<String> queuedCommand = getQueuedCommand(messageId);
    return queuedCommand.whenComplete(
            (result, throwable) -> queuedCommands_.remove(messageId, queuedCommand));
});
```

This ensures cleanup can only happen after the consumer has bound to the specific future instance, eliminating the race while still preventing the original leak.