### PR TITLE
fix #444 - KeyboardHandler#onPreKeyEvent() was never called

### DIFF
--- a/native/keyboard_handler.cpp
+++ b/native/keyboard_handler.cpp
@@ -51,7 +51,7 @@ bool KeyboardHandler::OnPreKeyEvent(CefRefPtr<CefBrowser> browser,
     return false;
 
   ScopedJNIBoolRef jboolRef(env, *is_keyboard_shortcut);
-  if (!jboolRef)
+  if (!jboolRef->get())
     return false;
 
   jboolean jresult = JNI_FALSE;


### PR DESCRIPTION
On the JNI KeyboardHandler::OnPreKeyEvent() is checking a jnull value value on the Java allocated ref. However for ScopedJNIBoolRef an implicit conversion to bool happened, leading to a false value and early return.

Fix #444 